### PR TITLE
Migration flag EQ-UQ TEPs 123

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ async function createTonWallet() {
   const { publicKey, secretKey } = keyPair
   const wallet = tonweb.wallet.create({ publicKey })
   const addr = await wallet.getAddress()
-  const address = addr.toString(true, true, true, false)
+  const address = addr.toString(true, true, false, false)
 
   if (showEveryWallet) {
     console.log(address)


### PR DESCRIPTION
Proposal that will prevent the loss of user funds in case of erroneous sending [address update proposal #123
](https://github.com/ton-blockchain/TEPs/pull/123)

Suggested behaviour:

7. `bounceable` flag from address representation should now be taken as "force-bounceable".

When sending, wallets must accept this flag as follows:

if `true` - all messages to this address can ONLY be sent in bounceable mode, even if the destination contract has an uninitialized state.

if `false` - means that a non-bounceable message can be sent to the destination address.
The wallet app checks the destination address - if it has an `uninitialized` state, then it sends a non-bounceable message, otherwise it sends a bounceable message.

Since only wallets will use the non-bounceable form, it will also be possible to distinguish the wallet from the service smart contract using this flag.

Old:
![image](https://github.com/TON-NFT/custon/assets/24755187/7afced50-bd94-45f3-b12f-e0272eac6168)

New:
![image](https://github.com/TON-NFT/custon/assets/24755187/c2b74205-3d3a-4264-8acd-d92a910ac628)
